### PR TITLE
feat(gitop): use standard io.ReadWriter interface as GetFile()'s output

### DIFF
--- a/internal/gitop/gitop.go
+++ b/internal/gitop/gitop.go
@@ -2,11 +2,11 @@ package gitop
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"sync"
 	"time"
 
-	"github.com/go-git/go-billy/v5"
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/object"
@@ -57,8 +57,8 @@ var mm, tv, readr = &Repository{
 	r:      nil,
 }
 
-// GetFile will return a File interface with read and write permission
-func (repo *Repository) GetFile(filenamePath string) (billy.File, error) {
+// GetFile will return an io.ReadWriter with read and write permission
+func (repo *Repository) GetFile(filenamePath string) (io.ReadWriter, error) {
 	worktree, err := repo.r.Worktree()
 	if err != nil {
 		return nil, nil


### PR DESCRIPTION
go-billy's File interface composites io.Writer, io.Reader, io.ReaderAt, io.Seeker, and io.Closer with additional convenient Lock and Unlock methods.

Since Major Tom clone the git repo in the memory, and the plan in progress is to treat the git requests in a queue with only one worker to process the queue, the Lock and Unlock methods are not critical to Major Tom.

For the sake of compatibility and clarity, I intent to treat go-billy's File as the implementation of io.ReaderWriter and avoid to deal with the problems of errors triggered by lockers.