### PR TITLE
Fix/gitop mishandle git operation

### DIFF
--- a/internal/gitop/git.go
+++ b/internal/gitop/git.go
@@ -1,13 +1,14 @@
 package gitop
 
 import (
+	"github.com/go-git/go-billy/v5/memfs"
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/storage/memory"
 	log "github.com/sirupsen/logrus"
 )
 
 func cloneGitRepo(opt git.CloneOptions) (*git.Repository, error) {
-	r, err := git.Clone(memory.NewStorage(), nil, &opt)
+	r, err := git.Clone(memory.NewStorage(), memfs.New(), &opt)
 
 	if err != nil {
 		return nil, err

--- a/internal/gitop/gitop.go
+++ b/internal/gitop/gitop.go
@@ -42,21 +42,24 @@ type Repository struct {
 	config map[string]string
 	once   *sync.Once
 	r      *git.Repository
-	locker sync.Mutex
+	locker *sync.Mutex
 }
 
 var mm, tv, readr = &Repository{
 	config: gitConfig["mm"],
 	once:   &sync.Once{},
 	r:      nil,
+	locker: &sync.Mutex{},
 }, &Repository{
 	config: gitConfig["tv"],
 	once:   &sync.Once{},
 	r:      nil,
+	locker: &sync.Mutex{},
 }, &Repository{
 	config: gitConfig["readr"],
 	once:   &sync.Once{},
 	r:      nil,
+	locker: &sync.Mutex{},
 }
 
 // GetFile will return an io.ReadWriter with read and write permission

--- a/internal/gitop/gitop.go
+++ b/internal/gitop/gitop.go
@@ -126,7 +126,7 @@ func commit(r *git.Repository, filename, name, email, message string) error {
 	}
 
 	fmt.Println(obj)
-	return nil
+	return err
 }
 
 func (repo *Repository) Pull() error {
@@ -136,12 +136,19 @@ func (repo *Repository) Pull() error {
 	if err != nil {
 		return err
 	}
-	return worktree.Pull(&git.PullOptions{
+	err = worktree.Pull(&git.PullOptions{
 		Auth:          repo.authMethod,
 		ReferenceName: plumbing.NewBranchReferenceName(repo.config["branch"]),
 		RemoteName:    "origin",
 		SingleBranch:  true,
 	})
+
+	if err.Error() == "already up-to-date" {
+		logrus.Infof("pulling repo, but it's already up-to-date")
+		err = nil
+	}
+
+	return err
 }
 
 func (repo *Repository) Push() error {

--- a/internal/gitop/gitop.go
+++ b/internal/gitop/gitop.go
@@ -90,7 +90,7 @@ func (repo *Repository) AddFile(filenamePath string) error {
 
 	_, err = worktree.Add(filenamePath)
 
-	logrus.Infof("$s is added to the staging area", filenamePath)
+	logrus.Infof("%s is added to the staging area", filenamePath)
 
 	return err
 }

--- a/internal/gitop/gitop.go
+++ b/internal/gitop/gitop.go
@@ -177,11 +177,10 @@ func getRepository(project string) (repo *Repository, err error) {
 		return nil, errors.New("wrong project")
 	}
 
-	repo.locker.Lock()
-	defer repo.locker.Unlock()
-
 	// Init git repo
 	repo.once.Do(func() {
+		repo.locker.Lock()
+		defer repo.locker.Unlock()
 		// Get the config according to the project
 		config := repo.config
 		key, errRead := os.ReadFile(config["sshKeyPath"])

--- a/internal/gitop/gitop_test.go
+++ b/internal/gitop/gitop_test.go
@@ -1,25 +1,24 @@
 package gitop
 
 import (
-	"fmt"
-	"reflect"
 	"sync"
 	"testing"
 
-	"github.com/go-git/go-billy/v5"
 	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing/transport/ssh"
 )
 
 func TestRepository_GetFile(t *testing.T) {
 	repo, err := GetRepository("tv")
 	if err != nil {
-		fmt.Println(err)
-		panic(1)
+		t.Error(err)
 	}
 	type fields struct {
-		config map[string]string
-		once   *sync.Once
-		r      *git.Repository
+		authMethod ssh.AuthMethod
+		config     map[string]string
+		once       *sync.Once
+		r          *git.Repository
+		locker     *sync.Mutex
 	}
 	type args struct {
 		filenamePath string
@@ -28,35 +27,36 @@ func TestRepository_GetFile(t *testing.T) {
 		name    string
 		fields  fields
 		args    args
-		want    billy.File
 		wantErr bool
 	}{
 		{
 			name: "dev for tv",
 			fields: fields{
-				config: gitConfig["tv"],
-				once:   repo.once,
-				r:      repo.r,
+				authMethod: repo.authMethod,
+				config:     gitConfig["tv"],
+				once:       repo.once,
+				r:          repo.r,
+				locker:     repo.locker,
 			},
 			args: args{
 				filenamePath: "cms/values-prod.yaml",
 			},
+			wantErr: false,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			repo := &Repository{
-				config: tt.fields.config,
-				once:   tt.fields.once,
-				r:      tt.fields.r,
+				authMethod: tt.fields.authMethod,
+				config:     tt.fields.config,
+				once:       tt.fields.once,
+				r:          tt.fields.r,
+				locker:     tt.fields.locker,
 			}
-			got, err := repo.GetFile(tt.args.filenamePath)
+			_, err := repo.GetFile(tt.args.filenamePath)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Repository.GetFile() error = %v, wantErr %v", err, tt.wantErr)
 				return
-			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("Repository.GetFile() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
gitop mis-handles some git operations like:
1. pull and commit without authorization method
2. a bug causing the initialization of repository to lock indefinitely